### PR TITLE
feat: implement sendLogs to ElasticSearch & fix node-fetch module issue

### DIFF
--- a/nodejs-example-logs-api-extension/.gitignore
+++ b/nodejs-example-logs-api-extension/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 # zip
 *.zip
+nodejs-example-logs-api-extension/node_modules

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/extensions-api.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/extensions-api.js
@@ -28,14 +28,14 @@ async function register() {
                     const extensionId = res.headers['lambda-extension-identifier'];
                     resolve(extensionId);
                 } else {
-                    console.error('register failed', data);
+                    // console.error('register failed', data);
                     reject(new Error('Registration failed'));
                 }
             });
         });
 
         req.on('error', (error) => {
-            console.error('register error:', error);
+            // console.error('register error:', error);
             reject(error);
         });
 
@@ -66,18 +66,18 @@ async function next(extensionId) {
                         const eventData = JSON.parse(data);
                         resolve(eventData);
                     } catch (error) {
-                        console.error('next failed', error);
+                        // console.error('next failed', error);
                         reject(error);
                     }
                 } else {
-                    console.error('next failed', data);
+                    // console.error('next failed', data);
                     reject(new Error('Next event failed'));
                 }
             });
         });
 
         req.on('error', (error) => {
-            console.error('next error:', error);
+            // console.error('next error:', error);
             reject(error);
         });
 

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -45,12 +45,16 @@ function processBatch(batch) {
                     }
                 }
             }
-            // console.log('DEBUG entry:', { message, ...data, });
+            
             const result = data ? {
                 time,
                 requestId,
                 ...data,
             } : {};
+
+            if(process.env.DEBUG_LAYER) {
+                console.log('PARSED RESULT DEBUG: ', result);
+            }
             return result;
         });
     return processedBatch.filter(obj => Object.keys(obj).length !== 0);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -34,9 +34,11 @@ function processBatch(batch) {
 
             if (level === 'ERROR') {
                 const stack = recordParts.slice(2).join(" ");
-                data = { stack, level: 'error' };
+                if (stack.includes('winston_log_agent')) {
+                    data = { stack, level: 'error' };
+                }
             } else {
-                let recordData = recordParts[3] + '';
+                let recordData = recordParts.slice(3).join(" ");
                 if(process.env.DEBUG_LAYER) {
                     console.log('RECORD DATA DEBUG: ', recordData);
                 }
@@ -44,7 +46,7 @@ function processBatch(batch) {
                     try {
                         data = parseRecord(recordData);
                     } catch (err) {
-                        data = { detail: recordParts.slice(3).join(" ") };
+                        data = { detail: recordData };
                     }
                 }
             }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -45,18 +45,18 @@ function processBatch(batch) {
 
                 if (level === 'ERROR') {
                     const stack = recordParts.slice(2).join(" ");
-                    if (stack.includes('winston_log_agent')) {
+                    if (!stack.includes('flushing')) { // filter out errors in flushing metrics
                         data = { stack, level: 'error' };
                     }
                 } else {
-                    let recordData = recordParts.slice(3).join(" ");
-                    if (recordData.includes('winston_log_agent')) {
-                        try {
-                            data = parseRecord(recordData);
-                        } catch (err) {
-                            data = { detail: recordData };
-                        }
-                    }
+                    // let recordData = recordParts.slice(3).join(" ");
+                    // if (recordData.includes('winston_log_agent')) {
+                    //     try {
+                    //         data = parseRecord(recordData);
+                    //     } catch (err) {
+                    //         data = { detail: recordData };
+                    //     }
+                    // }
                 }
 
                 result = data ? {

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -44,7 +44,7 @@ function processBatch(batch) {
                 }
             }
 
-            console.log('DEBUG entry:', { message, ...data, });
+            // console.log('DEBUG entry:', { message, ...data, });
             const result = {
                 time,
                 requestId,
@@ -67,32 +67,32 @@ function listen(address, port) {
                 body += data;
             });
             request.on('end', function () {
-                console.log('Logs listener received: ' + body);
+                // console.log('Logs listener received: ' + body);
                 try {
                     let batch = JSON.parse(body);
-                    console.log('DEBUG body:', body);
+                    // console.log('DEBUG body:', body);
                     // console.log('DEBUG batch:', batch);
                     const processedBatch = processBatch(batch);
-                    console.log('DEBUG processedBatch:', processedBatch);
+                    // console.log('DEBUG processedBatch:', processedBatch);
 
                     if (processedBatch.length > 0) {
                         logsQueue.push(...processedBatch);
                     }
                 } catch (e) {
-                    console.log("failed to parse logs");
+                    console.log("failed to parse logs", e);
                 }
                 response.writeHead(200, {})
                 response.end("OK")
             });
         } else {
-            console.log('GET');
+            // console.log('GET');
             response.writeHead(200, {});
             response.end("OK");
         }
     });
 
     server.listen(port, address);
-    console.log(`Listening for logs at http://${address}:${port}`);
+    // console.log(`Listening for logs at http://${address}:${port}`);
     return { logsQueue, server };
 }
 

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -21,7 +21,6 @@ function parseRecord(input) {
     });
 
     return parsedRecordObj;
-
 }
 function processBatch(batch) {
     const processedBatch = batch
@@ -41,7 +40,7 @@ function processBatch(batch) {
                 try {
                     data = parseRecord(recordParts[3]);
                 } catch (err) {
-                    message = recordParts[3];
+                    message = recordParts.slice(3).join(" ");
                 }
             }
 
@@ -52,7 +51,7 @@ function processBatch(batch) {
                 message,
                 ...data,
             }
-            return JSON.stringify(result);
+            return result;
         });
 
     return processedBatch;

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -30,7 +30,7 @@ function processBatch(batch) {
             const time = recordParts[0];
             const requestId = recordParts[1];
             const level = recordParts[2];
-            let data = {};
+            let data = undefined;
 
             if (level === 'ERROR') {
                 const stack = recordParts.slice(2).join(" ");

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -1,36 +1,61 @@
 const http = require('http');
 
+function transformRecord(input) {
+
+    // Step 1: Fix the single quotes and unescape the inner JSON in the message field
+    const formattedInput = input
+        .replace(/\n/g, "").replace(/\\"/g, '\\\\"') // Replace new lines & spaces
+
+    console.log(formattedInput);
+    // Step 2: Parse the entire JSON string (except the message field)
+    const result = JSON.parse(JSON.stringify(formattedInput));
+    return result;
+
+}
 function processBatch(batch) {
     const processedBatch = batch
-      .filter((item) => item.type === "function")
-      .map((item) => {
-        const recordParts = item.record.split("\t");
-        const time = recordParts[0];
-        const requestId = recordParts[1];
-        const level = recordParts[2];
-        const data = JSON.parse(recordParts[3]);
-  
-        return {
-          time,
-          requestId,
-          level,
-          ...data,
-        };
-      });
-  
+        .filter((item) => item.type === "function")
+        .map((item) => {
+            const recordParts = item.record.split("\t");
+            const time = recordParts[0];
+            const requestId = recordParts[1];
+            const level = recordParts[2];
+            let data = {};
+            let message = '';
+
+            if (level === 'ERROR') {
+                const stack = recordParts.slice(3).join("\t");
+                data = { stack, level: 'error' };
+            } else {
+                try {
+                    data = transformRecord(recordParts[3]);
+                } catch (err) {
+                    message = recordParts[3];
+                }
+            }
+
+
+            return {
+                time,
+                requestId,
+                message,
+                ...data,
+            };
+        });
+
     return processedBatch;
-  }
+}
 
 function listen(address, port) {
     const logsQueue = [];
     // init HTTP server for the Logs API subscription
-    const server = http.createServer(function(request, response) {
+    const server = http.createServer(function (request, response) {
         if (request.method == 'POST') {
             var body = '';
-            request.on('data', function(data) {
+            request.on('data', function (data) {
                 body += data;
             });
-            request.on('end', function() {
+            request.on('end', function () {
                 console.log('Logs listener received: ' + body);
                 try {
                     let batch = JSON.parse(body);
@@ -40,10 +65,10 @@ function listen(address, port) {
                     console.log('DEBUG processedBatch:', processedBatch);
 
                     if (processedBatch.length > 0) {
-                        logsQueue.push( ...processedBatch );
+                        logsQueue.push(...processedBatch);
                     }
-                } catch(e) { 
-                    console.log("failed to parse logs"); 
+                } catch (e) {
+                    console.log("failed to parse logs");
                 }
                 response.writeHead(200, {})
                 response.end("OK")
@@ -54,7 +79,7 @@ function listen(address, port) {
             response.end("OK");
         }
     });
-    
+
     server.listen(port, address);
     console.log(`Listening for logs at http://${address}:${port}`);
     return { logsQueue, server };

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -6,7 +6,6 @@ function transformRecord(input) {
     const formattedInput = input
         .replace(/\n/g, "").replace(/\\"/g, '\\\\"') // Replace new lines & spaces
 
-    console.log(formattedInput);
     // Step 2: Parse the entire JSON string (except the message field)
     const result = JSON.parse(JSON.stringify(formattedInput));
     return result;
@@ -34,7 +33,7 @@ function processBatch(batch) {
                 }
             }
 
-
+            console.log('DEBUG entry:', {message, ...data,});
             return {
                 time,
                 requestId,

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -37,6 +37,9 @@ function processBatch(batch) {
                 data = { stack, level: 'error' };
             } else {
                 let recordData = recordParts[3] + '';
+                if(process.env.DEBUG_LAYER) {
+                    console.log('RECORD DATA DEBUG: ', recordData);
+                }
                 if (recordData.includes('winston_log_agent')) {
                     try {
                         data = parseRecord(recordData);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -4,7 +4,7 @@ function parseRecord(input) {
 
     // Regular expressions for key and value
     const keyPattern = /(\w+):/g;
-    const valuePattern = /'([^']*)'/g;
+    const valuePattern = /(?:'([^']*)'|(?!'|\s*{)([^,}]*))/g;
 
     // Search regex
     const searchWithRegExp = new RegExp(`${keyPattern.source}\\s*${valuePattern.source}`, 'gm');
@@ -16,8 +16,8 @@ function parseRecord(input) {
     const parsedRecordObj = {};
     matches.forEach(match => {
         const key = match[1];
-        const value = match[2];
-        parsedRecordObj[key] = value.startsWith('{') ? JSON.parse(value) : value;
+        const value = match[2] !== undefined ? match[2] : match[3];
+        parsedRecordObj[key] = value;
     });
 
     return parsedRecordObj;

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -1,5 +1,26 @@
 const http = require('http');
 
+function processBatch(batch) {
+    const processedBatch = batch
+      .filter((item) => item.type === "function")
+      .map((item) => {
+        const recordParts = item.record.split("\t");
+        const time = recordParts[0];
+        const requestId = recordParts[1];
+        const level = recordParts[2];
+        const data = JSON.parse(recordParts[3]);
+  
+        return {
+          time,
+          requestId,
+          level,
+          ...data,
+        };
+      });
+  
+    return processedBatch;
+  }
+
 function listen(address, port) {
     const logsQueue = [];
     // init HTTP server for the Logs API subscription
@@ -14,9 +35,12 @@ function listen(address, port) {
                 try {
                     let batch = JSON.parse(body);
                     console.log('DEBUG body:', body);
-                    console.log('DEBUG batch:', batch);
-                    if (batch.length > 0) {
-                        logsQueue.push( ...batch );
+                    // console.log('DEBUG batch:', batch);
+                    const processedBatch = processBatch(batch);
+                    console.log('DEBUG processedBatch:', processedBatch);
+
+                    if (processedBatch.length > 0) {
+                        logsQueue.push( ...processedBatch );
                     }
                 } catch(e) { 
                     console.log("failed to parse logs"); 

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/http-listener.js
@@ -13,6 +13,8 @@ function listen(address, port) {
                 console.log('Logs listener received: ' + body);
                 try {
                     let batch = JSON.parse(body);
+                    console.log('DEBUG body:', body);
+                    console.log('DEBUG batch:', batch);
                     if (batch.length > 0) {
                         logsQueue.push( ...batch );
                     }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -36,7 +36,7 @@ const RECEIVER_NAME = 'sandbox';
 async function receiverAddress() {
   return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 }
-const ES_INDEX = `lambda-${process.env.AWS_LAMBDA_FUNCTION_NAME}`.toLowerCase;
+const ES_INDEX = `lambda-${process.env.AWS_LAMBDA_FUNCTION_NAME}`.toLowerCase();
 const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/${ES_INDEX}/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
 
 const RECEIVER_PORT = 4243;

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -36,8 +36,8 @@ const RECEIVER_NAME = 'sandbox';
 async function receiverAddress() {
   return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 }
-
-const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/my-index/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
+const ES_INDEX = `lambda-${process.env.AWS_LAMBDA_FUNCTION_NAME}`;
+const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/${ES_INDEX}/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
 
 const RECEIVER_PORT = 4243;
 const TIMEOUT_MS = 1000; // Maximum time (in milliseconds) that a batch is buffered.
@@ -101,7 +101,7 @@ const SUBSCRIPTION_BODY = {
 
                 req.write(postData);
                 req.end();
-                console.log('DEBUG: log processing & es exporting complete')
+                console.log('DEBUG: log processing & es exporting complete to endpoint:', ELASTICSEARCH_ENDPOINT);
 
             } catch (error) {
                 console.error(`[${this.agent_name}] Error: ${error}`, flush = true);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -36,7 +36,7 @@ const RECEIVER_NAME = 'sandbox';
 async function receiverAddress() {
   return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 }
-const ES_INDEX = `lambda-${process.env.AWS_LAMBDA_FUNCTION_NAME}`;
+const ES_INDEX = `lambda-${process.env.AWS_LAMBDA_FUNCTION_NAME}`.toLowerCase;
 const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/${ES_INDEX}/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
 
 const RECEIVER_PORT = 4243;

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -83,7 +83,7 @@ const SUBSCRIPTION_BODY = {
 
     // function for processing collected logs
     function sendLogsToElasticsearch() {
-        console.log(`collected ${logsQueue.length} log objects`);
+        // console.log(`collected ${logsQueue.length} log objects`);
         logsQueue.forEach(log => {
             try {
                 const postData = JSON.stringify(log);
@@ -98,7 +98,7 @@ const SUBSCRIPTION_BODY = {
 
                 const req = https.request(ELASTICSEARCH_ENDPOINT, options, (res) => {
                     // console.log(res);
-                    console.log(`Status code: ${res?.statusCode}`);
+                    // console.log(`Status code: ${res?.statusCode}`);
 
                     let responseData = '';
                     res.on('data', (chunk) => {
@@ -107,7 +107,7 @@ const SUBSCRIPTION_BODY = {
 
                     // This event listener is called when the response is complete
                     res.on('end', () => {
-                        console.log('Elastic Search Response Data:', responseData);
+                        // console.log('Elastic Search Response Data:', responseData);
                     });
                 });
 
@@ -115,9 +115,12 @@ const SUBSCRIPTION_BODY = {
                     console.error(`[${this.agent_name}] Error: ${error}`, flush = true);
                 });
 
+                if(process.env.DEBUG_LAYER) {
+                    console.log('POSTDATA DEBUG: ', postData);
+                }
                 req.write(postData);
                 req.end();
-                console.log('DEBUG: log processing & es exporting complete to endpoint:', ELASTICSEARCH_ENDPOINT);
+                // console.log('DEBUG: log processing & es exporting complete to endpoint:', ELASTICSEARCH_ENDPOINT);
 
             } catch (error) {
                 console.error(`[${this.agent_name}] Error: ${error}`, flush = true);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/index.js
@@ -2,17 +2,14 @@
 const { register, next } = require('./extensions-api');
 const { subscribe } = require('./logs-api');
 const { listen } = require('./http-listener');
-const AWS = require('aws-sdk');
-const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const https = require('https');
 
 /**
 
 Note: 
 
-- This is a simple example extension to make you help start investigating the Lambda Runtime Logs API.
-This code is not production ready, and it has never intended to be. Use it with your own discretion after you tested
-it thoroughly.  
-
+- This is a simple example extension to help you start investigating the Lambda Runtime Logs API.
+- It sends the Logs captured at runtime to elastic search without adding any latency as the extensions processing happens async in nature
 - Because of the asynchronous nature of the system, it is possible that logs for one invoke are
 processed during the next invoke slice. Likewise, it is possible that logs for the last invoke are processed during
 the SHUTDOWN event.
@@ -20,48 +17,44 @@ the SHUTDOWN event.
 */
 
 const EventType = {
-    INVOKE: 'INVOKE',
-    SHUTDOWN: 'SHUTDOWN',
+  INVOKE: 'INVOKE',
+  SHUTDOWN: 'SHUTDOWN',
 };
 
 function handleShutdown(event) {
-    console.log('shutdown', { event });
-    process.exit(0);
+  console.log('shutdown', { event });
+  process.exit(0);
 }
 
 function handleInvoke(event) {
-    console.log('invoke');
+  console.log('invoke');
 }
 
-const LOCAL_DEBUGGING_IP = "0.0.0.0";
-const RECEIVER_NAME = "sandbox";
+const LOCAL_DEBUGGING_IP = '0.0.0.0';
+const RECEIVER_NAME = 'sandbox';
 
 async function receiverAddress() {
-    return (process.env.AWS_SAM_LOCAL === 'true')
-        ? LOCAL_DEBUGGING_IP
-        : RECEIVER_NAME;
+  return process.env.AWS_SAM_LOCAL === 'true' ? LOCAL_DEBUGGING_IP : RECEIVER_NAME;
 }
 
-const BUCKET_NAME = process.env.LOGS_S3_BUCKET_NAME;
-const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME;
+const ELASTICSEARCH_ENDPOINT = process.env.ELASTICSEARCH_ADD_DOC_ENDPOINT || `https://${process.env.ES_ENDPOINT}/my-index/_doc`; // Replace with your Elasticsearch insertion endpoint along with <index>/_doc
 
-// Subscribe to platform logs and receive them on ${local_ip}:4243 via HTTP protocol.
 const RECEIVER_PORT = 4243;
-const TIMEOUT_MS = 1000 // Maximum time (in milliseconds) that a batch is buffered.
-const MAX_BYTES = 262144 // Maximum size in bytes that the logs are buffered in memory.
-const MAX_ITEMS = 10000 // Maximum number of events that are buffered in memory.
+const TIMEOUT_MS = 1000; // Maximum time (in milliseconds) that a batch is buffered.
+const MAX_BYTES = 262144; // Maximum size in bytes that the logs are buffered in memory.
+const MAX_ITEMS = 10000; // Maximum number of events that are buffered in memory.
 
 const SUBSCRIPTION_BODY = {
-    "destination":{
-        "protocol": "HTTP",
-        "URI": `http://${RECEIVER_NAME}:${RECEIVER_PORT}`,
-    },
-    "types": ["platform", "function"],
-    "buffering": {
-        "timeoutMs": TIMEOUT_MS,
-        "maxBytes": MAX_BYTES,
-        "maxItems": MAX_ITEMS
-    }
+  destination: {
+      protocol: 'HTTP',
+      URI: `http://${RECEIVER_NAME}:${RECEIVER_PORT}`,
+  },
+  types: ['platform', 'function'],
+  buffering: {
+      timeoutMs: TIMEOUT_MS,
+      maxBytes: MAX_BYTES,
+      maxItems: MAX_ITEMS,
+  },
 };
 
 (async function main() {
@@ -83,39 +76,53 @@ const SUBSCRIPTION_BODY = {
     await subscribe(extensionId, SUBSCRIPTION_BODY, server);
 
     // function for processing collected logs
-    async function uploadLogs() {
-        while (logsQueue.length > 0) {
-            console.log(`collected ${logsQueue.length} log objects`);
-            if (BUCKET_NAME) {
-                const date = (new Date()).toISOString().replace(/[^0-9]/gi,"-").substr(0,23);
-                const key = 'logs/'+FUNCTION_NAME+'/'+date+'.json';
-                console.log("logs uploading: "+key);
-                const params = { Bucket: BUCKET_NAME, Key: key };
-                params.Body = JSON.stringify(logsQueue); // serialize log queue and add to S3 put request
-                logsQueue.splice(0); // clear log queue
-                params.ContentType = 'application/json; charset=utf-8';
-                await s3.putObject(params).promise();
-                console.log("logs sent: "+key);
-            } else {
-                // You can do something else with logs in logsQueue.
-                logsQueue.splice(0); // clear log queue
+    function sendLogsToElasticsearch() {
+        console.log(`collected ${logsQueue.length} log objects`);
+        logsQueue.forEach(log => {
+            try {
+                const postData = JSON.stringify(log);
+                console.log('postdata DEBUG:', postData);
+                const options = {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Content-Length': Buffer.byteLength(postData),
+                    },
+                };
+
+                const req = https.request(ELASTICSEARCH_ENDPOINT, options, (res) => {
+                    console.log(res);
+                    console.log(`Status code: ${res?.statusCode}`);
+                });               
+
+                req.on('error', (error) => {
+                    console.error(`[${this.agent_name}] Error: ${error}`, flush = true);
+                });
+
+                req.write(postData);
+                req.end();
+                console.log('DEBUG: log processing & es exporting complete')
+
+            } catch (error) {
+                console.error(`[${this.agent_name}] Error: ${error}`, flush = true);
             }
-        }
+
+        });
     }
 
-    // execute extensions logic
+    // execute extensions logic to process & export Logs [events captured in the queue]
     while (true) {
         console.log('next');
         const event = await next(extensionId);
 
         switch (event.eventType) {
             case EventType.SHUTDOWN:
-                await uploadLogs(); // upload remaining logs, during shutdown event
+                sendLogsToElasticsearch(); // upload remaining logs, during shutdown event
                 handleShutdown(event);
                 break;
             case EventType.INVOKE:
                 handleInvoke(event);
-                await uploadLogs(); // upload queued logs, during invoke event
+                sendLogsToElasticsearch(); // send queued logs to Elasticsearch, during invoke event
                 break;
             default:
                 throw new Error('unknown event: ' + event.eventType);

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
@@ -23,15 +23,15 @@ async function subscribe(extensionId, subscriptionBody, server) {
             res.on('end', () => {
                 switch (res.statusCode) {
                     case 200:
-                        console.info('logs subscription ok: ', data);
+                        // console.info('logs subscription ok: ', data);
                         resolve();
                         break;
                     case 202:
-                        console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
+                        // console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
                         resolve();
                         break;
                     default:
-                        console.error('logs subscription failed: ', data);
+                        // console.error('logs subscription failed: ', data);
                         reject(new Error('Logs subscription failed'));
                         break;
                 }
@@ -39,7 +39,7 @@ async function subscribe(extensionId, subscriptionBody, server) {
         });
 
         req.on('error', (error) => {
-            console.error('logs subscription error:', error);
+            // console.error('logs subscription error:', error);
             reject(error);
         });
 

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/logs-api.js
@@ -1,31 +1,53 @@
-const fetch = require('node-fetch');
+const http = require('http');
 
 const baseUrl = `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-08-15/logs`;
 
 async function subscribe(extensionId, subscriptionBody, server) {
-    const res = await fetch(baseUrl, {
-        method: 'put',
-        body: JSON.stringify(subscriptionBody),
+    const requestBody = JSON.stringify(subscriptionBody);
+
+    const options = {
+        method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
             'Lambda-Extension-Identifier': extensionId,
-        }
-    });
+        },
+    };
 
-    switch(res.status) {
-        case 200:
-            console.info('logs subscription ok: ', await res.text());
-            break;
-        case 202:
-            console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
-            break;
-        default:
-            console.error('logs subscription failed: ', await res.text());
-            break;
-    }
+    return new Promise((resolve, reject) => {
+        const req = http.request(baseUrl, options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                switch (res.statusCode) {
+                    case 200:
+                        console.info('logs subscription ok: ', data);
+                        resolve();
+                        break;
+                    case 202:
+                        console.warn('WARNING!!! Logs API is not supported! Is this extension running in a local sandbox?');
+                        resolve();
+                        break;
+                    default:
+                        console.error('logs subscription failed: ', data);
+                        reject(new Error('Logs subscription failed'));
+                        break;
+                }
+            });
+        });
+
+        req.on('error', (error) => {
+            console.error('logs subscription error:', error);
+            reject(error);
+        });
+
+        req.write(requestBody);
+        req.end();
+    });
 }
 
 module.exports = {
     subscribe,
 };
-

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
@@ -9,13 +9,27 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "2.860.0"
+        "aws-sdk": "2.860.0",
+        "date-fns": "2.30.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/aws-sdk": {
       "version": "2.860.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
       "integrity": "sha512-BUBWw28PNDhRDnPEnXiPEvgTWD8Iyq5pl9lk/WhXC/vkACJ3aUVe+sicezI1/JQRjLrO3R6w7X20YknVWfAibA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -48,22 +62,61 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/buffer/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -71,12 +124,14 @@
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/jmespath": {
       "version": "0.15.0",
@@ -89,26 +144,34 @@
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "license": "MIT"
     },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "engines": {
         "node": ">=0.4.x"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
     },
     "node_modules/url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -118,7 +181,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -127,21 +190,37 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
       }
     },
+    "node_modules/xml2js/node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "license": "ISC"
+    },
     "node_modules/xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
     "aws-sdk": {
       "version": "2.860.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
@@ -171,6 +250,21 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        }
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
       }
     },
     "events": {
@@ -203,6 +297,11 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -229,6 +328,13 @@
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        }
       }
     },
     "xmlbuilder": {

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package-lock.json
@@ -1,8 +1,146 @@
 {
   "name": "nodejs-example-logs-api-extension",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "nodejs-example-logs-api-extension",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "aws-sdk": "2.860.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.860.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
+      "integrity": "sha512-BUBWw28PNDhRDnPEnXiPEvgTWD8Iyq5pl9lk/WhXC/vkACJ3aUVe+sicezI1/JQRjLrO3R6w7X20YknVWfAibA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
       "version": "2.860.0",
@@ -35,32 +173,10 @@
         "isarray": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
-    "fetch-blob": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -70,47 +186,32 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
-      }
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
     },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -120,11 +221,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "xml2js": {
       "version": "0.4.19",
@@ -138,7 +234,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
     }
   }
 }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.860.0"
+    "aws-sdk": "2.860.0",
+    "date-fns": "2.30.0"
   }
 }

--- a/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
+++ b/nodejs-example-logs-api-extension/nodejs-example-logs-api-extension/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.860.0",
-    "node-fetch": "^3.1.1"
+    "aws-sdk": "2.860.0"
   }
 }


### PR DESCRIPTION
- For NodeJS Logs API extension, update the processing of subscribed events to send it to Elastic Search instead of S3
- Add Parsing logic for object to be sent to Elastic Search
- Fix node-fetch module issue encountered while deploying this on higher node versions